### PR TITLE
ci: clippy::nursery を有効にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
 
 jobs:
   build_and_test:
@@ -48,13 +50,16 @@ jobs:
           crate: cargo-all-features
       
       - name: Build
-        run: cargo build-all-features --verbose
+        run: cargo build-all-features --all-targets --workspace --verbose
         
       - name: Test
-        run: cargo test
+        run: cargo test --all-targets --workspace --verbose
       
       - name: Format
         run: cargo fmt --all -- --check
 
       - name: Lint
-        run: cargo clippy --tests --workspace -- -D warnings
+        run: cargo clippy --all-targets --workspace --verbose -- '-Dclippy::all' -Dwarnings '-Dclippy::nursery'
+
+      - name: Lint document
+        run: cargo doc --no-deps --workspace --document-private-items --verbose

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -17,7 +17,7 @@ pub use text_with_frontmatter_loader::*;
 pub use yaml_loader::*;
 
 /// [`Loader`] reads [`Value`] from a file. There are several Loaders depending on the type of file.
-/// For example, [`FrontmatterLoader`](self::frontmatter_loader::FrontmatterLoader) usually loads markdown files, while [`StaticResourceLoader`](self::static_resource_loader::StaticResourceLoader) loads static resources.
+/// For example, [`TextWithFrontmatterLoader`] usually loads markdown files, while [`BlobLoader`] loads static resources as-is.
 /// Which Loader reads which file is specified by the user in the configuration file `tempura.json`.
 pub trait Loader {
     fn load(reader: impl Read) -> anyhow::Result<Value>;

--- a/src/pipeline/resource.rs
+++ b/src/pipeline/resource.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::Pipeline;
 
 /// Resource holds the file contents needed for the build process.
-/// One resource instance is created per [`Pipeline`](crate::pipeline::Pipeline).
+/// One resource instance is created per [`Pipeline`]
 #[derive(Debug)]
 pub struct Resource {
     value_map: HashMap<usize, Value>,


### PR DESCRIPTION
closes #107
